### PR TITLE
Provide an AMD with amdefine.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "protocol"
   ],
   "dependencies": {
+    "amdefine": "~1",
     "underscore": "1.5.2"
   },
   "devDependencies": {

--- a/src/i.js
+++ b/src/i.js
@@ -1,123 +1,127 @@
 'use strict';
 
-var _ = require('underscore');
-
-function noOp() {}
-
-function addFunctionNameToObject(functionName, object) {
-    if (functionName && _.isString(functionName)) {
-        object[functionName] = 'function';
-    }
+if (typeof define !== 'function') {
+    var define = require('amdefine')(module);
 }
 
-function processBlock(block, blockName, outObject) {
-    if (_.isArray(block[blockName])) {
-        outObject[blockName] = outObject[blockName] || {};
-        _.each(block[blockName], function (value) {
-            addFunctionNameToObject(value, outObject[blockName]);
-        });
-    } else if (_.isObject(block[blockName])) {
-        outObject[blockName] = outObject[blockName] || {};
-        _.each(block[blockName], function (value, key) {
-            addFunctionNameToObject(key, outObject[blockName]);
-        });
-    }
-}
+define(['underscore'], function (_) {
+    function noOp() {}
 
-function buildInterface(interfaceDescription) {
-    var result = {
-        required: {}
+    function addFunctionNameToObject(functionName, object) {
+        if (functionName && _.isString(functionName)) {
+            object[functionName] = 'function';
+        }
+    }
+
+    function processBlock(block, blockName, outObject) {
+        if (_.isArray(block[blockName])) {
+            outObject[blockName] = outObject[blockName] || {};
+            _.each(block[blockName], function (value) {
+                addFunctionNameToObject(value, outObject[blockName]);
+            });
+        } else if (_.isObject(block[blockName])) {
+            outObject[blockName] = outObject[blockName] || {};
+            _.each(block[blockName], function (value, key) {
+                addFunctionNameToObject(key, outObject[blockName]);
+            });
+        }
+    }
+
+    function buildInterface(interfaceDescription) {
+        var result = {
+            required: {}
+        };
+
+        if (_.isArray(interfaceDescription)) {
+            _.each(interfaceDescription, function (methodName) {
+                addFunctionNameToObject(methodName, result.required);
+            });
+        } else if (_.isObject(interfaceDescription)) {
+            processBlock(interfaceDescription, 'required', result);
+            processBlock(interfaceDescription, 'optional', result);
+        }
+
+        return result;
+    }
+
+    var Methodical = function (interfaceDescription) {
+        this._interface = buildInterface(interfaceDescription);
     };
 
-    if (_.isArray(interfaceDescription)) {
-        _.each(interfaceDescription, function (methodName) {
-            addFunctionNameToObject(methodName, result.required);
-        });
-    } else if (_.isObject(interfaceDescription)) {
-        processBlock(interfaceDescription, 'required', result);
-        processBlock(interfaceDescription, 'optional', result);
-    }
+    Methodical.function = 'function';
 
-    return result;
-}
+    Methodical.fromConstructor = function (Constructor) {
+        var requiredMethods;
 
-var Methodical = function (interfaceDescription) {
-    this._interface = buildInterface(interfaceDescription);
-};
+        if (_.isFunction(Constructor)) {
+            requiredMethods = [];
+            _.each(Constructor.prototype, function (value, key) {
+                if (_.isFunction(value)) {
+                    requiredMethods.push(key);
+                }
+            });
+        } else {
+            throw new TypeError('A function must be passed');
+        }
 
-Methodical.function = 'function';
+        return new Methodical(requiredMethods);
+    };
 
-Methodical.fromConstructor = function (Constructor) {
-    var requiredMethods;
+    Methodical.prototype.getInterface = function () {
+        return this._interface;
+    };
 
-    if (_.isFunction(Constructor)) {
-        requiredMethods = [];
-        _.each(Constructor.prototype, function (value, key) {
-            if (_.isFunction(value)) {
-                requiredMethods.push(key);
+    Methodical.prototype.check = function (object) {
+        var errors = [];
+
+        // ensures that if we pass garbage in, we get sensible error messages
+        if (!_.isObject(object)) {
+            object = {};
+        }
+
+        _.each(this.getInterface().required, _.bind(function (value, key) {
+            if (typeof object[key] !== value) {
+                errors.push('The required method "' + key + '" is not implemented');
             }
-        });
-    } else {
-        throw new TypeError('A function must be passed');
-    }
+        }, this));
 
-    return new Methodical(requiredMethods);
-};
-
-Methodical.prototype.getInterface = function () {
-    return this._interface;
-};
-
-Methodical.prototype.check = function (object) {
-    var errors = [];
-
-    // ensures that if we pass garbage in, we get sensible error messages
-    if (!_.isObject(object)) {
-        object = {};
-    }
-
-    _.each(this.getInterface().required, _.bind(function (value, key) {
-        if (typeof object[key] !== value) {
-            errors.push('The required method "' + key + '" is not implemented');
+        if (errors.length) {
+            var throwable = new TypeError();
+            var messageIntro = 'The object does not conform to the interface: ';
+            if (this.name) {
+                messageIntro = 'The object does not conform to the "' + this.name + '" interface: ';
+            }
+            throwable.message = messageIntro + errors.join('; ');
+            throw throwable;
         }
-    }, this));
 
-    if (errors.length) {
-        var throwable = new TypeError();
-        var messageIntro = 'The object does not conform to the interface: ';
-        if (this.name) {
-            messageIntro = 'The object does not conform to the "' + this.name + '" interface: ';
+    };
+
+    Methodical.prototype.complete = function (object) {
+
+        if (!_.isFunction(object) && !_.isObject(object)) {
+            throw new TypeError('Cannot complete a non-object');
         }
-        throwable.message = messageIntro + errors.join('; ');
-        throw throwable;
-    }
 
-};
+        _.each(this.getInterface().required, _.bind(function (value, key) {
+            if (typeof object[key] !== value) {
+                object[key] = noOp;
+            }
+        }, this));
+    };
 
-Methodical.prototype.complete = function (object) {
+    Methodical.prototype.tryCall = function (object, method) {
+        var methodArguments = Array.prototype.slice.call(arguments, 2);
+        this.tryApply(object, method, methodArguments);
+    };
 
-    if (!_.isFunction(object) && !_.isObject(object)) {
-        throw new TypeError('Cannot complete a non-object');
-    }
-
-    _.each(this.getInterface().required, _.bind(function (value, key) {
-        if (typeof object[key] !== value) {
-            object[key] = noOp;
+    Methodical.prototype.tryApply = function (object, method, args) {
+        if (_.isFunction(object[method])) {
+            object[method].apply(object, args);
+        } else if (this.getInterface().required[method] === 'function') {
+            object[method].apply(object, args);
         }
-    }, this));
-};
+    };
 
-Methodical.prototype.tryCall = function (object, method) {
-    var methodArguments = Array.prototype.slice.call(arguments, 2);
-    this.tryApply(object, method, methodArguments);
-};
-
-Methodical.prototype.tryApply = function (object, method, args) {
-    if (_.isFunction(object[method])) {
-        object[method].apply(object, args);
-    } else if (this.getInterface().required[method] === 'function') {
-        object[method].apply(object, args);
-    }
-};
-
-module.exports = Methodical;
+    return Methodical;
+});


### PR DESCRIPTION
Now usable as an AMD module while remaining compatible with node’s
require().
